### PR TITLE
feat: Implement KGH config manager and Ansible installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,101 @@ kgh pr create --title "Fix bug"  # Auto-añade --base main
 kgh --debug  # Modo debug
 ```
 
+### Configuration Management (`kgh config`)
+
+The `kgh` tool includes a configuration management system that allows you to customize its behavior. Configuration is stored in `~/.config/kgh/user_config.lua`.
+
+**View Current Configuration**
+
+To see all currently active configuration settings (including defaults merged with your user-specific settings), use:
+
+```bash
+kgh config list
+```
+
+*Example Output:*
+```
+pr.base=main
+user.name=Your Name
+```
+*(Actual output will vary based on your settings and defaults.)*
+
+**Get a Specific Configuration Value**
+
+To retrieve a specific configuration value by its key:
+
+```bash
+kgh config get pr.base
+```
+*Example Output:*
+```
+main
+```
+
+To get a value you've set:
+```bash
+kgh config get user.name
+```
+*Example Output:*
+```
+Your Name
+```
+If the key is not found, `kgh config get` will produce no output.
+
+**Set a Configuration Value**
+
+To set or update a configuration value:
+
+```bash
+kgh config set user.name "Your Full Name"
+kgh config set pr.reviewer "@yourgithubuser"
+kgh config set feature.defaultBranch "develop" 
+kgh config set project.id 123
+kgh config set enable.notifications true
+```
+
+This will create or update the value in your `~/.config/kgh/user_config.lua` file.
+Keys are dot-separated to represent structure. For example, `feature.defaultBranch` might be stored in a `feature` table within your Lua config file.
+
+*Example:*
+```bash
+# Set your name
+kgh config set user.name "Jane Doe"
+
+# Verify it's set
+kgh config get user.name
+# Output: Jane Doe
+
+# Set default PR reviewer
+kgh config set pr.reviewer "johndoe"
+
+# List all configs to see it
+kgh config list
+# Output might include:
+# pr.base=main
+# pr.reviewer=johndoe
+# user.name=Jane Doe
+```
+
+**Configuration File Location**
+
+Your personal configurations are stored at: `~/.config/kgh/user_config.lua`.
+This is a Lua file that returns a table. You can edit it directly, but using `kgh config set` is generally safer.
+
+*Example `user_config.lua` content:*
+```lua
+-- kgh user configuration file
+return {
+  user = {
+    name = "Jane Doe"
+  },
+  pr = {
+    reviewer = "johndoe"
+  }
+}
+```
+Defaults are merged with these settings at runtime. Your settings in `user_config.lua` will override any default values for the same keys.
+
 ### Python Tools
 *Coming soon...*
 
@@ -46,11 +141,22 @@ Este repositorio es tanto una herramienta como un registro de aprendizaje de:
 
 ## 🔧 Instalación
 
-```bash
-git clone https://github.com/tu-usuario/dev-toolkit.git
-cd dev-toolkit/lua-lib/kgh-wrapper
-sudo ./install.sh
-```
+The recommended way to install `kgh` and set up its basic configuration is by using the provided Ansible playbook. This requires Ansible to be installed on your system.
+
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/tu-usuario/dev-toolkit.git
+    cd dev-toolkit
+    ```
+    *(Replace `tu-usuario` with the actual repository owner/path if different.)*
+
+2.  **Run the Ansible playbook:**
+    ```bash
+    ansible-playbook ansible/install_kgh.yml
+    ```
+    This playbook will make the `kgh` script executable, create a symbolic link at `/usr/local/bin/kgh` (this may require sudo privileges, which Ansible will handle if configured for `become`), and set up an initial user configuration directory and file at `~/.config/kgh/user_config.lua`.
+
+    If you prefer manual installation or do not have Ansible, you can inspect the `ansible/install_kgh.yml` playbook to see the steps involved (e.g., creating a symlink and the user config file). The old `lua-lib/install.sh` script is no longer the recommended method for installing `kgh`.
 
 ---
 *Construyendo productividad, un comando a la vez.* ⚡

--- a/ansible/install_kgh.yml
+++ b/ansible/install_kgh.yml
@@ -1,0 +1,77 @@
+---
+- name: Install kgh CLI tool and setup user configuration
+  hosts: localhost
+  connection: local
+  vars:
+    # Assumes this playbook ('install_kgh.yml') is in an 'ansible' directory
+    # at the root of the dev-toolkit repository.
+    kgh_repo_base_path: "{{ playbook_dir }}/.." 
+    kgh_script_relative_path: "lua-lib/github.lua"
+    kgh_symlink_dest: "/usr/local/bin/kgh"
+    
+    # User-specific configuration (ansible_env.HOME resolves to the user's home dir)
+    user_kgh_config_dir: "{{ ansible_env.HOME }}/.config/kgh"
+    user_kgh_config_file: "{{ user_kgh_config_dir }}/user_config.lua"
+
+  tasks:
+    - name: Determine absolute path for kgh script
+      ansible.builtin.command: "realpath {{ kgh_repo_base_path }}/{{ kgh_script_relative_path }}"
+      register: realpath_kgh_script
+      changed_when: false # This command does not change state
+      check_mode: no # Always run this, even in check mode, to get the path
+
+    - name: Set kgh_script_abs_path fact
+      ansible.builtin.set_fact:
+        kgh_script_abs_path: "{{ realpath_kgh_script.stdout }}"
+
+    - name: Ensure kgh source script exists
+      ansible.builtin.stat:
+        path: "{{ kgh_script_abs_path }}"
+      register: kgh_script_file_stat
+      
+    - name: Fail if kgh source script not found
+      ansible.builtin.fail:
+        msg: "kgh source script not found at {{ kgh_script_abs_path }}. Check paths."
+      when: not kgh_script_file_stat.stat.exists
+
+    - name: Ensure the kgh Lua script is executable
+      ansible.builtin.file:
+        path: "{{ kgh_script_abs_path }}"
+        mode: "0755" # rwxr-xr-x
+      
+    - name: Create symbolic link for kgh command using sudo
+      ansible.builtin.file:
+        src: "{{ kgh_script_abs_path }}" # Must be absolute path for symlink with sudo
+        dest: "{{ kgh_symlink_dest }}"
+        state: link
+        force: yes # Equivalent to ln -sf
+      become: yes # Requires sudo privileges
+      notify: Display kgh symlink info
+
+    - name: Ensure user kgh configuration directory exists
+      ansible.builtin.file:
+        path: "{{ user_kgh_config_dir }}"
+        state: directory
+        mode: "0755" 
+      # Runs as the user executing the playbook (no 'become')
+
+    - name: Ensure default user kgh configuration file exists
+      ansible.builtin.copy:
+        content: |
+          -- kgh user configuration file
+          -- This file stores user-specific settings for kgh.
+          return {}
+        dest: "{{ user_kgh_config_file }}"
+        force: no # Do not overwrite if it already exists
+        mode: "0644" # rw-r--r--
+      register: user_config_file_action
+      # Runs as the user executing the playbook (no 'become')
+
+    - name: Report status of user configuration file
+      ansible.builtin.debug:
+        msg: "User kgh config file at {{ user_kgh_config_file }} was {{ 'created' if user_config_file_action.changed else 'already present or not overwritten' }}."
+
+  handlers:
+    - name: Display kgh symlink info
+      ansible.builtin.debug:
+        msg: "kgh command symlink created/updated: {{ kgh_symlink_dest }} -> {{ kgh_script_abs_path }}"

--- a/lua-lib/config_manager.lua
+++ b/lua-lib/config_manager.lua
@@ -1,0 +1,300 @@
+-- lua-lib/config_manager.lua
+local debug = require("kgh_debug") 
+local fs = require("lfs") -- For checking file/directory existence
+
+local ConfigManager = {}
+
+-- Path to user configuration
+local user_config_dir = os.getenv("HOME") .. "/.config/kgh"
+local user_config_path = user_config_dir .. "/user_config.lua"
+
+-- Default configuration (can be expanded later)
+local default_config = {
+  pr = {
+    base = "main"
+  }
+}
+
+-- Function to safely load user configuration
+function ConfigManager.load_user_config()
+    debug.info("Attempting to load user config from: " .. user_config_path)
+    -- Ensure the directory exists before trying to read the file
+    -- This check is more relevant for 'set', but good to be aware of.
+    -- For 'get', if the dir or file doesn't exist, it's not an error, just no user config.
+    if fs.attributes(user_config_path, "mode") == "file" then
+        local status, config_or_error = pcall(dofile, user_config_path)
+        if status and type(config_or_error) == "table" then
+            debug.success("User config loaded successfully.")
+            debug.config(config_or_error) -- Log the loaded user config
+            return config_or_error
+        elseif not status then
+            debug.error("Error loading user_config.lua: " .. tostring(config_or_error))
+            return {} -- Return empty table on error to prevent breaking
+        else
+            debug.warn("user_config.lua did not return a table or was empty.")
+            return {} -- Return empty table if file doesn't return a table
+        end
+    else
+        debug.info("User config file not found at: " .. user_config_path .. ". Using defaults only.")
+        return {} -- Return empty table if file doesn't exist
+    end
+end
+
+-- Function to merge default and user configurations
+function ConfigManager.get_merged_config()
+    local user_cfg = ConfigManager.load_user_config()
+    local final_config = {}
+
+    -- Deep copy defaults to avoid modifying the original default_config table
+    for k, v in pairs(default_config) do
+        if type(v) == "table" then
+            final_config[k] = {}
+            for k2, v2 in pairs(v) do
+                final_config[k][k2] = v2
+            end
+        else
+            final_config[k] = v
+        end
+    end
+
+    -- Merge user config into final_config, overriding defaults
+    for k, v in pairs(user_cfg) do
+        if type(v) == "table" and type(final_config[k]) == "table" then
+            -- Merge nested tables (one level deep for simplicity, can be made recursive)
+            for k2, v2 in pairs(v) do
+                final_config[k][k2] = v2
+            end
+        else
+            -- This handles top-level keys and overwrites nested tables if types don't match
+            final_config[k] = v
+        end
+    end
+    debug.info("Final merged config being used:", final_config)
+    return final_config
+end
+
+-- Function to get a configuration value by key (e.g., "pr.base")
+function ConfigManager.get_value(key)
+    if not key or key == "" then
+        debug.error("ConfigManager.get_value: key is nil or empty")
+        print("Error: Configuration key cannot be empty.")
+        return nil
+    end
+    debug.info("ConfigManager.get_value called for key: '" .. key .. "'")
+
+    local config_table = ConfigManager.get_merged_config()
+    
+    local keys = {}
+    for k_part in string.gmatch(key, "[^%.]+") do
+        table.insert(keys, k_part)
+    end
+
+    if #keys == 0 then
+        debug.error("ConfigManager.get_value: Parsed key is empty for input key '" .. key .. "'")
+        print("Error: Invalid configuration key format.")
+        return nil
+    end
+
+    local current_value = config_table
+    for i, k_part in ipairs(keys) do
+        if type(current_value) == "table" and current_value[k_part] ~= nil then
+            current_value = current_value[k_part]
+        else
+            debug.warn("Key part '" .. k_part .. "' (from key '" .. key .. "') not found or current value is not a table.")
+            return nil -- Key part not found or path interrupted
+        end
+    end
+    
+    debug.success("Value for key '" .. key .. "': " .. tostring(current_value))
+    return current_value
+end
+
+-- Helper function to convert a Lua table to a string representation for saving
+function ConfigManager.serialize_lua_table(tbl, indent_level)
+    indent_level = indent_level or 0
+    local indent_str = string.rep("  ", indent_level)
+    local next_indent_str = string.rep("  ", indent_level + 1)
+    local s = "{\n"
+    local first = true
+
+    -- Consistent ordering for more stable output (optional, but good for diffs)
+    local keys_to_serialize = {}
+    for k in pairs(tbl) do table.insert(keys_to_serialize, k) end
+    table.sort(keys_to_serialize)
+
+    for _, k in ipairs(keys_to_serialize) do
+        local v = tbl[k]
+        if not first then
+            s = s .. ",\n"
+        end
+        first = false
+
+        s = s .. next_indent_str
+        if type(k) == "string" then
+            -- Check if key is a valid Lua identifier, else use ["key"] format
+            if string.match(k, "^[_%a][_%w]*$") then
+                s = s .. k .. ' = '
+            else
+                s = s .. '["' .. tostring(k) .. '"] = '
+            end
+        else
+            s = s .. '[' .. tostring(k) .. '] = ' -- For non-string keys (e.g. numbers if ever used)
+        end
+
+        if type(v) == "table" then
+            s = s .. ConfigManager.serialize_lua_table(v, indent_level + 1)
+        elseif type(v) == "string" then
+            s = s .. '"' .. tostring(v):gsub('"', '\\"'):gsub("\n", "\\n") .. '"' -- Escape quotes and newlines
+        elseif type(v) == "boolean" then
+            s = s .. tostring(v)
+        elseif type(v) == "number" then
+            s = s .. tostring(v)
+        else
+            s = s .. '"UNKNOWN_TYPE[' .. type(v) .. ']"' 
+            debug.warn("serialize_lua_table: Unhandled type '" .. type(v) .. "' for key: " .. tostring(k))
+        end
+    end
+    s = s .. "\n" .. indent_str .. "}"
+    return s
+end
+
+-- Function to save the user configuration table to user_config.lua
+function ConfigManager.save_user_config(config_table)
+    debug.info("Attempting to save user config to: " .. user_config_path)
+
+    if fs.attributes(user_config_dir, "mode") ~= "directory" then
+        debug.info("User config directory not found, creating: " .. user_config_dir)
+        local success, err = fs.mkdir(user_config_dir)
+        if not success then
+            debug.error("Failed to create directory " .. user_config_dir .. ": " .. tostring(err))
+            print("Error: Could not create configuration directory: " .. user_config_dir)
+            return false
+        end
+        debug.success("Created directory: " .. user_config_dir)
+    end
+
+    local serialized_config = "return " .. ConfigManager.serialize_lua_table(config_table)
+    debug.info("Serialized config to save:", serialized_config)
+
+    local file, err = io.open(user_config_path, "w")
+    if not file then
+        debug.error("Failed to open " .. user_config_path .. " for writing: " .. tostring(err))
+        print("Error: Could not open configuration file for writing: " .. user_config_path)
+        return false
+    end
+
+    local bytes_written, write_err = file:write(serialized_config)
+    if not bytes_written then -- Check if write returned nil or false (error)
+        debug.error("Failed to write to " .. user_config_path .. ": " .. tostring(write_err))
+        file:close()
+        print("Error: Could not write to configuration file: " .. user_config_path .. (write_err and (": " .. write_err) or ""))
+        return false
+    end
+
+    file:close()
+    debug.success("User config saved successfully to: " .. user_config_path)
+    return true
+end
+
+-- Function to set a configuration value by key (e.g., "pr.base")
+function ConfigManager.set_value(key, value)
+    if not key or key == "" then
+        debug.error("ConfigManager.set_value: key is nil or empty")
+        print("Error: Configuration key cannot be empty.")
+        return false
+    end
+    -- Allow empty string for value, but not nil.
+    if value == nil then
+        debug.error("ConfigManager.set_value: value is nil for key '" .. key .. "'")
+        print("Error: Configuration value cannot be nil. To remove a key, use 'kgh config unset <key>' (not yet implemented).")
+        return false
+    end
+
+    debug.info("ConfigManager.set_value called for key: '" .. key .. "' with value: '" .. tostring(value) .. "' of type " .. type(value))
+
+    local user_cfg = ConfigManager.load_user_config() 
+    if user_cfg == nil then user_cfg = {} end 
+
+    local keys = {}
+    for k_part in string.gmatch(key, "[^%.]+") do
+        table.insert(keys, k_part)
+    end
+
+    if #keys == 0 then
+        debug.error("ConfigManager.set_value: Parsed key is empty for input key '" .. key .. "'")
+        print("Error: Invalid configuration key format.")
+        return false
+    end
+
+    local current_table = user_cfg
+    for i = 1, #keys - 1 do
+        local k_part = keys[i]
+        if not current_table[k_part] or type(current_table[k_part]) ~= "table" then
+            current_table[k_part] = {}
+        end
+        current_table = current_table[k_part]
+    end
+
+    current_table[keys[#keys]] = value 
+    debug.info("Updated user_cfg table (before saving):", user_cfg)
+
+    return ConfigManager.save_user_config(user_cfg)
+end
+
+-- Helper function to flatten the configuration table for 'list' command
+-- Takes a table and an optional prefix for nested keys.
+function ConfigManager.flatten_config_table(tbl, prefix)
+    local result_lines = {}
+    prefix = prefix or ""
+
+    -- Create a sorted list of keys for consistent output order
+    local keys = {}
+    for k in pairs(tbl) do
+        table.insert(keys, k)
+    end
+    table.sort(keys)
+
+    for _, k in ipairs(keys) do
+        local v = tbl[k]
+        local current_key_str
+        if prefix == "" then
+            current_key_str = tostring(k)
+        else
+            current_key_str = prefix .. "." .. tostring(k)
+        end
+
+        if type(v) == "table" then
+            -- Recursively flatten nested tables
+            local nested_lines = ConfigManager.flatten_config_table(v, current_key_str)
+            for _, line in ipairs(nested_lines) do
+                table.insert(result_lines, line)
+            end
+        else
+            -- Add key=value string to results
+            table.insert(result_lines, current_key_str .. "=" .. tostring(v))
+        end
+    end
+    return result_lines
+end
+
+-- Function to list all configurations (merged default and user)
+function ConfigManager.list_configs()
+    debug.info("ConfigManager.list_configs called.")
+    local merged_config = ConfigManager.get_merged_config() -- This already logs the merged config
+    
+    if not merged_config or next(merged_config) == nil then
+        debug.info("No configurations (merged) found to list.")
+        return {} 
+    end
+
+    local flat_list = ConfigManager.flatten_config_table(merged_config)
+    
+    if #flat_list == 0 then
+        debug.info("Flattened configuration list is empty (e.g. empty tables).")
+    else
+        debug.info("Flattened configuration list for display:", flat_list)
+    end
+    return flat_list -- Return as a list of strings "key=value"
+end
+
+return ConfigManager


### PR DESCRIPTION
This commit introduces a configuration management system for the KGH tool, allowing you to get, set, and list configurations (e.g., `kgh config set user.name "Jane Doe"`). Your specific settings are stored in `~/.config/kgh/user_config.lua`.

Key features:
- `kgh config get <key>`: Retrieves a configuration value.
- `kgh config set <key> <value>`: Sets a configuration value.
- `kgh config list`: Lists all active configurations.
- Default configurations are merged with your settings.

Additionally, this commit adds an Ansible playbook (`ansible/install_kgh.yml`) as the new recommended method for installing `kgh`. The README.md has been updated to reflect these changes, including usage examples for the config manager and new installation instructions.